### PR TITLE
log resource won't work inline in a library; use Chef::Log.info instead

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -46,7 +46,7 @@ module EphemeralLvm
 
         # Servers running on Xen hypervisor require the block device to be in /dev/xvdX instead of /dev/sdX
         if node.attribute?('virtualization') && node['virtualization']['system'] == "xen"
-          log "Mapping for devices: #{ephemeral_devices.inspect}"
+          Chef::Log.info "Mapping for devices: #{ephemeral_devices.inspect}"
           ephemeral_devices = EphemeralLvm::Helper.fix_device_mapping(
             ephemeral_devices,
             node['block_device'].keys


### PR DESCRIPTION
This causes a compile error when the hypervisor is Xen.
