### PR TITLE
installs xfsprogs package when FS is xfs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ group :integration do
 end
 
 group :test do
-  gem 'chefspec', '~> 1.3'
+  gem 'chefspec', '~> 3.2'
   gem 'strainer', '~> 3.0'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,9 @@
 #
 include_recipe "lvm"
 
+# install XFS bins when necessary
+package 'xfsprogs' if node['ephemeral_lvm']['filesystem'] == 'xfs'
+
 if !node.attribute?('cloud') || !node['cloud'].attribute?('provider')
   log "Not running on a known cloud, not setting up ephemeral LVM"
 else

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,16 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+describe 'ephemeral_lvm::default' do
+  let(:runner) { ChefSpec::Runner.new }
+  let(:chef_run) { runner.converge(described_recipe) }
+
+  it 'does not install xfsprogs by default' do
+    expect(chef_run).to_not install_package('xfsprogs')
+  end
+
+  it 'installs xfsprogs when the filesystem is "xfs"' do
+    runner.node.set['ephemeral_lvm']['filesystem'] = 'xfs'
+    expect(chef_run).to install_package('xfsprogs')
+  end
+end


### PR DESCRIPTION
Whenever a user indicates that they want to a volume using the "xfs" filesystem, we should install the appropriate package that will allow them to do so:

**NOTE:** I noticed that there is dependency on 'chefspec' in the Gemfile but no actual specs written using that library. So, I updated the dependency and used it to actual write some specs for these changes.
