### PR TITLE
Fix for EBS stop/start

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ gem 'thor-foodcritic'
 gem 'thor-scmversion'
 
 group :integration do
-  gem 'test-kitchen', '~> 1.1.0'
+  gem 'test-kitchen', '~> 1.2.1'
   gem 'kitchen-vagrant'
 end
 
 group :test do
-  gem 'chefspec', '~> 1.3'
-  gem 'strainer', '~> 3.0'
+  gem 'chefspec', '~> 3.4.0'
+  gem 'strainer', '~> 3.3.0'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,7 @@ else
       logical_volume node['ephemeral_lvm']['logical_volume_name'] do
         size node['ephemeral_lvm']['logical_volume_size']
         filesystem node['ephemeral_lvm']['filesystem']
-        mount_point node['ephemeral_lvm']['mount_point']
+        mount_point location: node['ephemeral_lvm']['mount_point'], options: ['defaults', 'noauto']
         if ephemeral_devices.size > 1
           stripes ephemeral_devices.size
           stripe_size node['ephemeral_lvm']['stripe_size'].to_i

--- a/test/integration/default/bats/verify_ephemeral.bats
+++ b/test/integration/default/bats/verify_ephemeral.bats
@@ -28,5 +28,5 @@ export PATH=$PATH:/sbin:/usr/sbin
 @test "ephemeral logical volume is mounted to /mnt/ephemeral" {
   mountpoint /mnt/ephemeral
   mount | grep "/dev/mapper/vg--data-ephemeral0 on /mnt/ephemeral type ext3"
-  grep -P "/dev/mapper/vg--data-ephemeral0\s+/mnt/ephemeral\s+ext3" /etc/fstab
+  grep -P "/dev/mapper/vg--data-ephemeral0\s+/mnt/ephemeral\s+ext3\s+defaults,noauto\s" /etc/fstab
 }

--- a/test/integration/gce/bats/verify_ephemeral.bats
+++ b/test/integration/gce/bats/verify_ephemeral.bats
@@ -34,5 +34,5 @@ export PATH=$PATH:/sbin:/usr/sbin
 @test "ephemeral logical volume is mounted to /mnt/ephemeral" {
   mountpoint /mnt/ephemeral
   mount | grep "/dev/mapper/vg--data-ephemeral0 on /mnt/ephemeral type ext3"
-  grep -P "/dev/mapper/vg--data-ephemeral0\s+/mnt/ephemeral\s+ext3" /etc/fstab
+  grep -P "/dev/mapper/vg--data-ephemeral0\s+/mnt/ephemeral\s+ext3\s+defaults,noauto\s" /etc/fstab
 }


### PR DESCRIPTION
- Do not automatically mount the ephemeral LVM since epehemeral volumes
  are actually ephemeral and will not come back after stop/start.
