### PR TITLE
Removes static options from LVM mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Place the `ephemeral_lvm::default` in the runlist and the ephemeral devices will
 
 * `node['ephemeral_lvm']['filesystem']` - the filesystem to be used on the ephemeral volume. Default: `'ext4'`
 * `node['ephemeral_lvm']['mount_point']` - the mount point for the ephemeral volume. Default: `'/mnt/ephemeral'`
+* `node['ephemeral_lvm']['mount_point_properties']` - the options used when mounting the ephemeral volume. Default: `{options: ['defaults', 'noauto'], pass: 0}`
 * `node['ephemeral_lvm']['volume_group_name']` - the volume group name for the ephemeral LVM. Default: `'vg-data'`
 * `node['ephemeral_lvm']['logical_volume_size']` - the size to be used for the ephemeral LVM. Default: `'100%VG'` - This will use all available space in the volume group.
 * `node['ephemeral_lvm']['logical_volume_name']` - the name of the logical volume for ephemeral LVM. Default: `'ephemeral0'`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,8 +21,10 @@
 default['ephemeral_lvm']['filesystem'] = "ext4"
 
 # The ephemeral mount point
-default['ephemeral_lvm']['mount_point'] = {
-  location: "/mnt/ephemeral",
+default['ephemeral_lvm']['mount_point'] = "/mnt/ephemeral"
+
+# The ephemeral mount point options
+default['ephemeral_lvm']['mount_point_properties'] = {
   options: ["defaults", "noauto"],
   pass: 0
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,11 @@
 default['ephemeral_lvm']['filesystem'] = "ext4"
 
 # The ephemeral mount point
-default['ephemeral_lvm']['mount_point'] = "/mnt/ephemeral"
+default['ephemeral_lvm']['mount_point'] = {
+  location: "/mnt/ephemeral",
+  options: ["defaults", "noauto"],
+  pass: 0
+}
 
 # The ephemeral volume group name
 default['ephemeral_lvm']['volume_group_name'] = "vg-data"

--- a/metadata.rb
+++ b/metadata.rb
@@ -28,6 +28,13 @@ attribute "ephemeral_lvm/mount_point",
   :recipes => ["ephemeral_lvm::default"],
   :required => "recommended"
 
+attribute "ephemeral_lvm/mount_point_properties",
+  :display_name => "Ephemeral LVM Mount Properties",
+  :description => "The options used when mounting the ephemeral volume",
+  :default => {:options => ["defaults", "noauto"], :pass => 0},
+  :recipes => ["ephemeral_lvm::default"],
+  :required => "optional"
+
 attribute "ephemeral_lvm/volume_group_name",
   :display_name => "Ephemeral LVM Volume Group Name",
   :description => "The volume group name for the ephemeral LVM",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,9 @@ else
       logical_volume node['ephemeral_lvm']['logical_volume_name'] do
         size node['ephemeral_lvm']['logical_volume_size']
         filesystem node['ephemeral_lvm']['filesystem']
-        mount_point node['ephemeral_lvm']['mount_point']
+        mount_point node['ephemeral_lvm']['mount_point_properties'].merge(
+          location: node['ephemeral_lvm']['mount_point']
+        )
         if ephemeral_devices.size > 1
           stripes ephemeral_devices.size
           stripe_size node['ephemeral_lvm']['stripe_size'].to_i

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,7 @@ else
       logical_volume node['ephemeral_lvm']['logical_volume_name'] do
         size node['ephemeral_lvm']['logical_volume_size']
         filesystem node['ephemeral_lvm']['filesystem']
-        mount_point location: node['ephemeral_lvm']['mount_point'], options: ['defaults', 'noauto'], pass: 0
+        mount_point node['ephemeral_lvm']['mount_point']
         if ephemeral_devices.size > 1
           stripes ephemeral_devices.size
           stripe_size node['ephemeral_lvm']['stripe_size'].to_i


### PR DESCRIPTION
I updated my version of the ephemeral_lvm cookbook (v1.0.3 -> v1.0.8) only to find that my attribute setting for the mount point no longer worked.

```ruby
default['ephemeral_lvm']['mount_point'] = {
  location: '/mnt/ephemeral',
  options: 'defaults,noatime',
  dump: 0,
  pass: 0
}
```

Does it not make sense to allow the user to leverage all of the available mounting options?

Also, this change maintains the same default options as before.