### PR TITLE
Update lvm cookbook version dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ supports 'ubuntu'
 supports 'centos'
 supports 'debian'
 
-depends 'lvm', '~> 1.1.0'
+depends 'lvm', '~> 1.3.1'
 
 recipe "ephemeral_lvm::default", "Sets up ephemeral devices on a cloud server"
 


### PR DESCRIPTION
This version of the **lvm** cookbook works with Chef 12 (older versions do not) and doesn't break backwards compatibility.