### PR TITLE
Using include_recipe_now technic to allow compile time lvm2 package run

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,6 +11,7 @@ supports 'centos'
 supports 'debian'
 
 depends 'lvm', '~> 1.3.6'
+depends 'now'
 
 recipe "ephemeral_lvm::default", "Sets up ephemeral devices on a cloud server"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Configures available ephemeral devices on a cloud server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.11'
+version          '1.0.12'
 
 supports 'ubuntu'
 supports 'centos'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 
 # Include the lvm::default recipe which sets up the resources/providers for lvm
 #
-include_recipe "lvm"
+include_recipe_now "lvm"
 
 if !node.attribute?('cloud') || !node['cloud'].attribute?('provider') || !node.attribute?(node['cloud']['provider'])
   log "Not running on a known cloud, not setting up ephemeral LVM"


### PR DESCRIPTION
Until Chef will allow installing easily packages during compile time I suggest to use opscode 'now' cookbook with include_recipe_now resource to run lvm cookbook resources during compile time. 
