### PR TITLE
Update for new GCE ephemeral disk data structure

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -59,11 +59,11 @@ module EphemeralLvm
         case cloud
         when 'gce'
           # According to the GCE documentation, the instances have links for ephemeral disks as
-          # /dev/disk/by-id/google-ephemeral-disk-*. Refer to
-          # https://developers.google.com/compute/docs/disks#scratchdisks for more information.
+          # /dev/disk/by-id/google-local-ssd-*. Refer to
+          # https://cloud.google.com/compute/docs/disks/local-ssd for more information.
           #
-          ephemeral_devices = node[cloud]['attached_disks']['disks'].map do |disk|
-            if disk['type'] == "EPHEMERAL" && disk['deviceName'].match(/^ephemeral-disk-\d+$/)
+          ephemeral_devices = node[cloud]['instance']['disks'].map do |disk|
+            if disk['type'] == "EPHEMERAL" && disk['deviceName'].match(/^local-ssd-\d+$/)
               "/dev/disk/by-id/google-#{disk["deviceName"]}"
             end
           end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Configures available ephemeral devices on a cloud server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.11'
+version          '1.0.12'
 
 supports 'ubuntu'
 supports 'centos'


### PR DESCRIPTION
GCE ephemeral disks are now implemented as local SSDs. This change updates the cookbook to support them.