### PR TITLE
fixed gce ephemeral storage detection

### DIFF
--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -63,7 +63,7 @@ module EphemeralLvm
           # https://developers.google.com/compute/docs/disks#scratchdisks for more information.
           #
           ephemeral_devices = node[cloud]['attached_disks']['disks'].map do |disk|
-            if disk['type'] == "EPHEMERAL" && disk['deviceName'].match(/^ephemeral-disk-\d+$/)
+            if disk['type'] == "EPHEMERAL" && disk['deviceName'].match(/^local-ssd-\d+$/)
               "/dev/disk/by-id/google-#{disk["deviceName"]}"
             end
           end


### PR DESCRIPTION
fixed GCE ephemeral storage detection which is currently broken 
Currently GCE provides the following /dev/disks/by-id naming
```
ls -la /dev/disk/by-id/
total 0
lrwxrwxrwx 1 root root   9 Apr 13 18:48 google-local-ssd-0 -> ../../sdb
lrwxrwxrwx 1 root root   9 Apr 13 18:48 google-local-ssd-1 -> ../../sdc
lrwxrwxrwx 1 root root   9 Apr 13 18:48 google-local-ssd-2 -> ../../sdd
lrwxrwxrwx 1 root root   9 Apr 13 18:48 google-local-ssd-3 -> ../../sde

```
which is exposed by ohai
```
"gce": {
    "attached_disks": {
      "disks": [
        {
          "deviceName": "persistent-disk-0",
          "index": 0,
          "mode": "READ_WRITE",
          "type": "PERSISTENT"
        },
        {
          "deviceName": "local-ssd-0",
          "index": 1,
          "mode": "READ_WRITE",
          "type": "EPHEMERAL"
        },
        {
          "deviceName": "local-ssd-1",
          "index": 2,
          "mode": "READ_WRITE",
          "type": "EPHEMERAL"
        },
        {
          "deviceName": "local-ssd-2",
          "index": 3,
          "mode": "READ_WRITE",
          "type": "EPHEMERAL"
        },
        {
          "deviceName": "local-ssd-3",
          "index": 4,
          "mode": "READ_WRITE",
          "type": "EPHEMERAL"
        }
      ]
    },

```

Tested using the following ohai version
```
/opt/rightscale/sandbox/bin/ohai -v
Ohai: 6.18.0.2
```