### PR TITLE
fixed gce ephemeral storage detection

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Configures available ephemeral devices on a cloud server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.14'
+version          '1.0.15'
 
 supports 'ubuntu'
 supports 'centos'


### PR DESCRIPTION
as asked in https://github.com/rightscale-cookbooks/ephemeral_lvm/pull/42 