### PR TITLE
Added attribute for wipe_attributes to pass along to the lvm_volump_g…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,3 +42,7 @@ default['ephemeral_lvm']['logical_volume_name'] = "ephemeral0"
 
 # The stripe size in kilobytes to be used if more than one ephemeral disk is found
 default['ephemeral_lvm']['stripe_size'] = 512
+
+# Whether to wipe signatures on any existing drives
+default['ephemeral_lvm']['wipe_signatures'] = false
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Configures available ephemeral devices on a cloud server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.15'
+version          '1.0.16'
 
 supports 'ubuntu'
 supports 'centos'
@@ -64,3 +64,11 @@ attribute "ephemeral_lvm/stripe_size",
   :default => "512",
   :recipes => ["ephemeral_lvm::default"],
   :required => "optional"
+
+attribute "ephemeral_lvm/wipe_signatures",
+  :display_name => "Ephemeral LVM Wire Signatures",
+  :description => "Whether to wipe any existing filesystem signatures",
+  :default => false,
+  :recipes => ["ephemeral_lvm::default"],
+  :required => "optional"
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,6 +58,8 @@ else
     # they are created with LVM stripes with the stripe size set in the attributes.
     #
     lvm_volume_group node['ephemeral_lvm']['volume_group_name'] do
+      wipe_signatures node['ephemeral_lvm']['wipe_signatures']
+
       physical_volumes ephemeral_devices
 
       logical_volume node['ephemeral_lvm']['logical_volume_name'] do


### PR DESCRIPTION
…roup resource

I'm NOT an expert in Chef yet, but this works for me with test kitchen, both without an attribute and with specifying an attribute in the .kitchen.yml file.
