### PR TITLE
Wipe signatures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ gem 'thor-foodcritic'
 gem 'thor-scmversion'
 
 group :integration do
-  gem 'test-kitchen', '~> 1.2.1'
+  gem 'test-kitchen', '~> 1.2'
   gem 'kitchen-vagrant'
 end
 
 group :test do
-  gem 'chefspec', '~> 3.4.0'
-  gem 'strainer', '~> 3.3.0'
+  gem 'chefspec', '~> 3.4'
+  gem 'strainer', '~> 3.3'
 end


### PR DESCRIPTION
This updates #46, which adds support for `wipe_signatures`.

This PR loosens the Gemfile constraints, which were preventing a newer version of Ridley solving the [build error](https://travis-ci.org/rightscale-cookbooks/ephemeral_lvm/builds/125138768) in the other PR.
