### PR TITLE
set minimum lvm cookbook version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ supports 'ubuntu'
 supports 'centos'
 supports 'debian'
 
-depends 'lvm', '~> 1.6.1'
+depends 'lvm', '>= 1.6.1'
 
 recipe "ephemeral_lvm::default", "Sets up ephemeral devices on a cloud server"
 


### PR DESCRIPTION
This fixes issue #51 where lvm cookbook is being too restricted.