### PR TITLE
Add support for NVMe devices in EC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ ephemeral_lvm Cookbook CHANGELOG
 
 This file is used to list changes made in each version of the ephemeral_lvm cookbook.
 
+v3.0.1
+------
+- Fixed detection for NVMe ephemeral devices in EC2
+
 v3.0.0
 ------
 - locks to [lvm](https://github.com/chef-cookbooks/lvm) >= 4.0, Issues: ([#60][], [#62][]), PR: [#61][]

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -71,6 +71,9 @@ module EphemeralLvm
         # Removes nil elements from the ephemeral_devices array if any.
         ephemeral_devices.compact!
 
+        # Add all NVMe devices
+        ephemeral_devices.concat Dir.glob('/dev/nvme*n*')
+
         # Servers running on Xen hypervisor require the block device to be in /dev/xvdX instead of /dev/sdX
         if node.attribute?('virtualization') && node['virtualization']['system'] == 'xen'
           Chef::Log.info "Mapping for devices: #{ephemeral_devices.inspect}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Configures available ephemeral devices on a cloud server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.0'
+version          '3.0.1'
 issues_url       'https://github.com/rightscale-cookbooks/ephemeral_lvm/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/rightscale-cookbooks/ephemeral_lvm' if respond_to?(:source_url)
 chef_version '>= 12.0' if respond_to?(:chef_version)


### PR DESCRIPTION
New i3 instance family provides NVMe devices mapped as nvme0n1, nvme1n1, ... These aren't currently recognised by the cookbook. Since they aren't correctly described by instance metadata either, I decided to add all available NVMe devices.