### PR TITLE
Additional device support

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,9 +6,9 @@ DEPENDENCIES
     path: test/cookbooks/fake
 
 GRAPH
-  ephemeral_lvm (3.0.0)
+  ephemeral_lvm (3.0.1)
     lvm (>= 4.0.0)
     now (>= 0.0.0)
   fake (0.1.1)
-  lvm (4.0.5)
+  lvm (4.1.13)
   now (1.0.0)

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,8 +6,8 @@ DEPENDENCIES
     path: test/cookbooks/fake
 
 GRAPH
-  ephemeral_lvm (3.0.1)
-    lvm (>= 4.0.0)
+  ephemeral_lvm (3.0.2)
+    lvm (>= 4.0.6)
     now (>= 0.0.0)
   fake (0.1.1)
   lvm (4.1.13)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Place the `ephemeral_lvm::default` in the runlist and the ephemeral devices will
 * `node['ephemeral_lvm']['logical_volume_size']` - the size to be used for the ephemeral LVM. Default: `'100%VG'` - This will use all available space in the volume group.
 * `node['ephemeral_lvm']['logical_volume_name']` - the name of the logical volume for ephemeral LVM. Default: `'ephemeral0'`
 * `node['ephemeral_lvm']['stripe_size']` - the stripe size to be used for the ephemeral logical volume. Default: `512`
+* `node['ephemeral_lvm']['additonal_devices']` - array of additional devices to add to stripe.  Use if we are not finding them in metadata.  default: []
 
 # Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,3 +46,6 @@ default['ephemeral_lvm']['stripe_size'] = 512
 
 # Whether to wipe signatures on any existing drives
 default['ephemeral_lvm']['wipe_signatures'] = false
+
+# Array of devices to force into the ephemeral device list 
+default['ephemeral_lvm']['additonal_devices'] = []

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -56,6 +56,7 @@ module EphemeralLvm
     #
     def self.get_ephemeral_devices(cloud, node)
       ephemeral_devices = []
+      ephemeral_devices.concat node['ephemeral_lvm']['additonal_devices']
       # Detects the ephemeral disks available on the instance.
       #
       # If the cloud plugin supports block device mapping on the node, obtain the

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Configures available ephemeral devices on a cloud server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.1'
+version          '3.0.2'
 issues_url       'https://github.com/rightscale-cookbooks/ephemeral_lvm/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/rightscale-cookbooks/ephemeral_lvm' if respond_to?(:source_url)
 chef_version '>= 12.0' if respond_to?(:chef_version)

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ supports 'centos'
 supports 'debian'
 
 depends 'now'
-depends 'lvm', '>= 4.0'
+depends 'lvm', '>= 4.0.6'
 
 recipe 'ephemeral_lvm::default', 'Sets up ephemeral devices on a cloud server'
 


### PR DESCRIPTION
This does not directly fix #65 , but it does allow you to specify devices to include in LVM via attributes.  For example:
```
node.override['ephemeral_lvm']['additonal_devices'] = [ "/dev/nvme0n1" ]
include_recipe 'ephemeral_lvm'
```